### PR TITLE
Fixed indicatorView y-pos is displaced when menubar height changed.

### DIFF
--- a/Pod/Classes/RMPScrollingMenuBar.m
+++ b/Pod/Classes/RMPScrollingMenuBar.m
@@ -528,6 +528,12 @@
     _barHeight = barHeight;
     
     [self sizeToFit];
+
+    // indicatorView repositioning.
+    CGRect frame = _indicatorView.frame;
+    frame.origin.y = self.bounds.size.height - 4;
+    _indicatorView.frame = frame;
+    
     [self layoutIfNeeded];
 }
 


### PR DESCRIPTION
Reposition indicatorView y-position when RMPScrollingMenuBar#barHeight changed.